### PR TITLE
Link Foundation/Council sites; remove Mathieu Gauthron from team

### DIFF
--- a/content/page/about/governance.md
+++ b/content/page/about/governance.md
@@ -214,6 +214,13 @@ hero_icon: "fa-solid fa-scale-balanced"
       </div>
     </div>
   </div>
+
+  <div class="mt-12 text-center">
+    <a href="https://veranacouncil.org" target="_blank" rel="noopener" class="inline-flex items-center gap-2 text-verana hover:text-verana-light font-semibold transition-colors">
+      Visit the Verana Council website
+      <i class="fa-solid fa-arrow-up-right-from-square text-sm"></i>
+    </a>
+  </div>
 {{< /gov-section >}}
 
 {{< gov-section
@@ -312,6 +319,13 @@ hero_icon: "fa-solid fa-scale-balanced"
       class="mt-32 bg-green-900/10 border border-green-500/30 rounded-2xl p-8 text-center"
       description_class="text-lg text-gray-300 max-w-3xl mx-auto"
   >}}
+
+  <div class="mt-12 text-center">
+    <a href="https://veranafoundation.org" target="_blank" rel="noopener" class="inline-flex items-center gap-2 text-verana hover:text-verana-light font-semibold transition-colors">
+      Visit the Verana Foundation website
+      <i class="fa-solid fa-arrow-up-right-from-square text-sm"></i>
+    </a>
+  </div>
 {{< /gov-section >}}
 
 {{< gov-cta

--- a/content/page/about/team.md
+++ b/content/page/about/team.md
@@ -32,15 +32,6 @@ disable_content_wrapper: true
 >}}
 
 {{< team-member
-    name="Mathieu Gauthron"
-    position="Head of Network"
-    bio="Technology leader with deep expertise in distributed systems, overseeing the development of the Verana Network to ensure scalability, reliability, and long-term resilience."
-    linkedin="https://www.linkedin.com/in/mathieugauthron/"
-    github="https://github.com/matlux"
-    photo="/images/team/mathieu.jpeg"
->}}
-
-{{< team-member
     name="Philip A. Bildner"
     position="Strategic Advisor"
     bio="Advisor with a background spanning law, finance, and blockchain governance, guiding Verana’s strategic direction, ecosystem partnerships, and capital strategy."
@@ -121,7 +112,7 @@ Development of the first Verifiable User Agent, the [Hologram Messaging App](htt
     icon="fa-solid fa-network-wired"
     side="left"
 >}}
-Mathieu Gauthron joins to lead the first decentralized, blockchain-based Verifiable Public Registry (VPR) implementation.
+The team begins the first decentralized, blockchain-based Verifiable Public Registry (VPR) implementation.
 
 {{< team-chronology-highlight
     align="right"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -54,6 +54,10 @@ params:
         items:
           - label: "About"
             url: "/page/about/team"
+          - label: "Verana Foundation"
+            url: "https://veranafoundation.org"
+          - label: "Verana Council"
+            url: "https://veranacouncil.org"
           - label: "Visual Identity & Press"
             url: "/page/identity"
       - title: "Developers"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -91,20 +91,6 @@
         },
         {
           "@type": "Person",
-          "name": "Mathieu Gauthron",
-          "jobTitle": "Head of Network",
-          "worksFor": {
-            "@type": "Organization",
-            "name": "Verana Foundation"
-          },
-          "image": "https://verana.io/images/team/mathieu.jpeg",
-          "sameAs": [
-            "https://www.linkedin.com/in/mathieugauthron/",
-            "https://github.com/matlux"
-          ]
-        },
-        {
-          "@type": "Person",
           "name": "Philip A. Bildner",
           "jobTitle": "Strategic Advisor",
           "worksFor": {


### PR DESCRIPTION
## Summary

Three small content changes to verana.io:

### 1. Remove Mathieu Gauthron from the team
- Removed his **leadership card** from the Team page (`content/page/about/team.md`).
- Removed the matching **JSON-LD `Person` entry** from the home-page structured data (`layouts/index.html`) so the SEO schema stays consistent with the visible page.
- The 2023 "Network Development" chronology milestone previously read *"Mathieu Gauthron joins to lead the first decentralized, blockchain-based VPR implementation."* — reworded to *"The team begins the first decentralized, blockchain-based VPR implementation."* (keeps the milestone, drops the name, per request).

### 2. Footer — link the Foundation and Council sites
Added two items to the **Verana** column in `hugo.yaml`, between *About* and *Visual Identity & Press*:
- **Verana Foundation** → https://veranafoundation.org
- **Verana Council** → https://veranacouncil.org

### 3. Governance page — link both sites
On `content/page/about/governance.md`:
- The **Verana Council** section now ends with a *"Visit the Verana Council website"* link → veranacouncil.org
- The **Verana Foundation** section now ends with a *"Visit the Verana Foundation website"* link → veranafoundation.org

(Both styled with the existing `text-verana` link treatment and an external-link icon, opening in a new tab.)

## Verification

- `hugo --gc --minify` builds clean (exit 0, no shortcode/template errors).
- Rendered output checked: footer shows both new links on every page; governance page renders both website links in the correct sections; team page no longer mentions Gauthron anywhere; home-page JSON-LD still parses as valid JSON and no longer contains his `Person` entry.
- `grep` across `content/` and `layouts/` confirms zero remaining references to the name, the `matlux` GitHub handle, or `mathieu.jpeg`.

Branched from current `main`.
