### PR TITLE
fix(resolve): stale cached UNTRUSTED must not mask a recovered resolver

### DIFF
--- a/app/api/resolve/route.ts
+++ b/app/api/resolve/route.ts
@@ -14,12 +14,23 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const result = await resolveDid(did, "full");
+    // Always hit the resolver live: a stale cached UNTRUSTED must never mask
+    // a fixed/refreshed resolver (the upstream caches evaluations itself).
+    const result = await resolveDid(did, "full", 30_000, { fresh: true });
     // Best-effort extras from the DID documents (logos, credential URLs).
     const enrichment = await getPotEnrichment(result).catch(() => ({}));
     return NextResponse.json(
       { ...result, enrichment },
-      { headers: { "Cache-Control": "public, max-age=120" } }
+      {
+        headers: {
+          // Only a positive verdict is briefly cacheable by the browser;
+          // negative verdicts must re-check so recoveries show immediately.
+          "Cache-Control":
+            result.trustStatus === "TRUSTED"
+              ? "public, max-age=60"
+              : "no-store",
+        },
+      }
     );
   } catch {
     return NextResponse.json(

--- a/app/lib/verana.ts
+++ b/app/lib/verana.ts
@@ -80,17 +80,25 @@ export async function listTrustRegistries(
   return data.trust_registries ?? [];
 }
 
-/** Trust-resolve a DID against the resolver. */
+/** Trust-resolve a DID against the resolver.
+ *
+ *  `fresh: true` bypasses Next's data cache entirely — used by the
+ *  interactive Resolve-a-DID widget so that a fixed/refreshed resolver is
+ *  reflected immediately (the upstream resolver has its own ~1h evaluation
+ *  cache, so this stays cheap). The default cached mode is for background
+ *  aggregation (the latest-trusted-ecosystems scan), where a cached UNTRUSTED
+ *  only means an entry appears in the list up to 10 minutes late. */
 export async function resolveDid(
   did: string,
   detail: "summary" | "full" = "summary",
-  timeoutMs = 30_000
+  timeoutMs = 30_000,
+  opts: { fresh?: boolean } = {}
 ): Promise<ResolveResult> {
   const url =
     `${RESOLVER_URL}/v1/trust/resolve` +
     `?did=${encodeURIComponent(did)}&detail=${detail}`;
   const res = await fetch(url, {
-    next: { revalidate: 600 },
+    ...(opts.fresh ? { cache: "no-store" as const } : { next: { revalidate: 600 } }),
     signal: AbortSignal.timeout(timeoutMs),
   });
   if (!res.ok) throw new Error(`resolver failed: ${res.status}`);


### PR DESCRIPTION
When trust resolution failed and the resolver was then fixed (e.g. via a forced refresh) and answered TRUSTED, the website kept showing UNTRUSTED.

Cause: two cache layers on our side — the widget's resolver fetch sat in Next's data cache for 10 minutes (failures included), and `/api/resolve` told the browser to cache for another 2.

Fix:
- The interactive Resolve-a-DID path now always hits the resolver live (`cache: "no-store"`); the upstream resolver keeps its own ~1h evaluation cache, so this stays cheap.
- Response caching is verdict-aware: TRUSTED → `max-age=60`; anything else → `no-store`, so recoveries show immediately.
- The background latest-trusted-ecosystems scan keeps the 10-minute cached mode, where staleness only delays a list entry.

Verified locally: trusted/untrusted header split confirmed, and repeated widget calls reach the upstream directly.