### PR TITLE
feat(home): copy pass from external feedback round

### DIFF
--- a/app/ecosystems/page.tsx
+++ b/app/ecosystems/page.tsx
@@ -711,7 +711,7 @@ export default function Ecosystems() {
     <>
       <PageHero
         eyebrow="Sovereign ecosystems · 1 of 3"
-        title="Join or build an ecosystem"
+        title="Build your own trust ecosystem"
         intro="Verana is public, permissionless infrastructure: anyone can create their own trust ecosystem, or join the ecosystems they want."
       />
 

--- a/app/ecosystems/page.tsx
+++ b/app/ecosystems/page.tsx
@@ -888,7 +888,9 @@ export default function Ecosystems() {
               A fraction of every paid trust operation is committed to the
               participant&apos;s trust deposit as Trust Units (TU), and the
               deposit balance is the{" "}
-              <strong className="text-ink">trust score</strong>.
+              <strong className="text-ink">trust score</strong>. The deposit
+              exists to make bad actors sanctionable: it is skin in the game
+              that an ecosystem authority can slash for misbehavior.
             </p>
 
             <div className="card reveal mt-6 overflow-hidden">

--- a/app/lib/content.ts
+++ b/app/lib/content.ts
@@ -6,13 +6,14 @@ export const HERO = {
   eyebrow: "OPEN · PUBLIC · NEUTRAL",
   headline: "The Open Trust Infrastructure for the Verifiable Internet",
   subhead:
-    "Join and build sovereign digital trust ecosystems. Attach verifiable credentials to your services and agents, and make them identifiable, verifiable, and discoverable.",
+    "Build sovereign trust ecosystems on open standards (W3C Verifiable Credentials and DIDs, DIDComm), or join existing ones. Attach credentials to your services and AI agents, and make them identifiable, verifiable, and discoverable.",
 };
 
 export type ThreePart = {
   name: string;
   label: string;
   tone: "primary" | "accent" | "success";
+  audience: string;
   body: string;
   signature?: string;
   href: string;
@@ -24,13 +25,15 @@ export const THREE_PARTS: ThreePart[] = [
     name: "Trust Ecosystems",
     label: "Sovereign ecosystems",
     tone: "primary",
-    body: "Join or build ecosystems that issue and verify any credential. Each ecosystem self-defines its schemas, governance framework, participants, and business model.",
+    audience: "for ecosystem builders and joiners",
+    body: "Build ecosystems that issue and verify any credential, with your own schemas, governance framework, participants, and business model. Or join an existing one as an accredited issuer, verifier, or holder.",
     href: "/ecosystems",
   },
   {
     name: "Verifiable Trust",
     label: "Verifiable identity",
     tone: "accent",
+    audience: "for services, AI agents, and their operators",
     body: "Identify any service and the organization or person that controls it, and verify it before you connect.",
     signature: "Verify first. Then connect.",
     href: "/identity",
@@ -39,6 +42,7 @@ export const THREE_PARTS: ThreePart[] = [
     name: "The Trust Graph",
     label: "Discovery",
     tone: "success",
+    audience: "for users, agents, and search",
     body: "Discover services and ecosystems by the credentials they hold, ranked by trust. A first-class surface for AI-agent discovery.",
     href: "/discovery",
   },
@@ -144,7 +148,7 @@ export const USE_CASES: UseCase[] = [
       "Utopia creates its own GovID Ecosystem on the public registry: it publishes its governance framework, defines the GovID credential schema, and accredits participants.",
       "The Interior Ministry, as issuer grantor, accredits the regional civil registries. They issue GovID credentials to citizens, who hold them in their own wallets.",
       "A citizen opens a bank account in minutes: the bank, an accredited verifier, checks the GovID against the registry in real time and pays a verification fee that flows up the accreditation tree.",
-      "Everything runs on sovereign infrastructure Utopia hosts in its own jurisdiction: no SaaS, no vendor lock-in, and MOSIP-based national ID systems plug in directly.",
+      "Everything runs on sovereign infrastructure Utopia hosts in its own jurisdiction: no SaaS, no vendor lock-in, and MOSIP-based national ID systems plug in directly. The accreditation tree scales to thousands of relying parties without bilateral integrations.",
     ],
     mechanics: [
       { label: "How ecosystems work", href: "/ecosystems" },
@@ -152,14 +156,14 @@ export const USE_CASES: UseCase[] = [
     ],
   },
   {
-    name: "Enterprise & human credentials",
-    actors: "Acme Corp, its employees, its suppliers, and certification bodies.",
+    name: "Sectorial ecosystems",
+    actors: "Acme Corp, its employees, its suppliers, and certification bodies; the same pattern serves health, transport, notaries, and any sector body.",
     pain: "Employee access, partner onboarding, and B2B trust all rest on accounts, PDFs, and claims nobody can verify. An ISO certificate is a logo on a slide.",
     story: [
       "Acme registers its Main Organization service and identifies everything it runs: it issues ECS-Service credentials to its services and ECS-Badge credentials to its employees.",
       "A certification body accredited by an ISO ecosystem audits Acme and issues its ISO 9001 credential. The certification becomes provable, not asserted.",
       "Before ordering, Acme's systems verify the supplier's organization credential against the registry: B2B trust checked in real time, not assumed.",
-      "The same rails carry diplomas, professional certifications, and reusable KYC/KYB: join an existing ecosystem as issuer or verifier, the fastest path to production.",
+      "The same rails serve every sector: health, transport, notaries, enterprises extended to their partners. Join an existing sector ecosystem as issuer or verifier, the fastest path to production, or govern your own.",
     ],
     mechanics: [
       { label: "The Acme worked example", href: "/ecosystems" },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,6 +53,10 @@ export default function Home() {
               Build on Verana
             </Button>
           </div>
+          <p className="reveal mt-10 font-mono text-xs tracking-wide text-muted">
+            open standards · W3C DIDs · W3C Verifiable Credentials · DIDComm ·
+            OpenID4VC · TRQP
+          </p>
         </Container>
       </section>
 
@@ -79,6 +83,9 @@ export default function Home() {
                   />
                 </div>
                 <h3 className="display mt-3 text-xl text-ink">{p.name}</h3>
+                <p className="mt-1 font-mono text-[11px] text-muted">
+                  {p.audience}
+                </p>
                 <p className="mt-2 flex-1 text-sm text-muted">{p.body}</p>
                 {p.signature ? (
                   <p className="mt-3 font-mono text-xs text-success-ink">
@@ -103,9 +110,9 @@ export default function Home() {
         <Container className="grid gap-10 lg:grid-cols-2">
           <div>
             <SectionHeading
-              eyebrow={`Live from ${NETWORK_NAME}`}
+              eyebrow={`2 · Verifiable identity · live from ${NETWORK_NAME}`}
               title="Watch verify-first work"
-              intro="Resolve a real DID and see its Proof-of-Trust: the service, the organization behind it, and the verified chain up to the ecosystem root."
+              intro="This is the second part above, running for real. Resolve a real DID and see its Proof-of-Trust: the service, the organization behind it, and the verified chain up to the ecosystem root."
             />
             <div className="reveal mt-6">
               <ResolveDid compact />
@@ -137,8 +144,8 @@ export default function Home() {
         <Container>
           <SectionHeading
             eyebrow="Use cases"
-            title="One trust infrastructure, many entry points"
-            intro="Overlapping lenses, not silos: a bank doing reusable KYC today runs AI agents tomorrow. They all converge on the same verify-first primitive."
+            title="Humans and AI agents, verified the same way"
+            intro="One trust infrastructure, many entry points, built for what's coming: a bank doing reusable KYC today runs AI agents tomorrow. Every lens converges on the same verify-first primitive."
           />
           <div className="reveal-stagger mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {USE_CASES.map((u, i) => (


### PR DESCRIPTION
Implements the accepted items from the external feedback round, per spec-v2 decision 11. Copy and naming only; no layout, data, or route changes.

## Home
- **Hero subhead leads with *build*** while staying dual-audience: "Build sovereign trust ecosystems on open standards (W3C Verifiable Credentials and DIDs, DIDComm), or join existing ones." The standards are now named on the first screen, plus a mono standards strip under the CTAs (W3C DIDs · W3C VCs · DIDComm · OpenID4VC · TRQP).
- **Audience signposts on the three-part cards** ("for ecosystem builders and joiners" / "for services, AI agents, and their operators" / "for users, agents, and search") so the page never shifts addressee silently. Card 1 body is now build-first, join-second.
- **Live section tied to part 2**: eyebrow "2 · Verifiable identity · live from testnet" and intro "This is the second part above, running for real."
- **Use-cases teaser leads with the convergence message**: "Humans and AI agents, verified the same way", with the bank-KYC line demoted to an illustration.

## Use cases (shared content)
- **Lens renamed**: "Enterprise & human credentials" → **"Sectorial ecosystems"**, with the sectors named (health, transport, notaries, enterprises extended to their partners). Propagates to the home teaser and the /use-cases scene automatically.
- **Governments story** gains the scalability angle: the accreditation tree scales to thousands of relying parties without bilateral integrations.

## Ecosystems
- The trust-score lede now states the deposit's **purpose**: making bad actors sanctionable (skin in the game an ecosystem authority can slash).

Explicitly not done (decided): audience stays dual (build AND join); no "digital twins" terminology for the connected-objects lens.

Verified: clean production build (19/19 pages), visual check of home (hero, cards, live tie, teaser), /use-cases scene 02, and /ecosystems trust-score section in light and dark mode.