### PR TITLE
feat(home): reorder sections and split the live-proof block

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -132,36 +132,38 @@ export default function Home() {
         </Container>
       </Section>
 
-      {/* Live proof: the network is real */}
+      {/* Live proof — verifiable identity, resolve a DID */}
       <Section>
-        <Container className="grid gap-10 lg:grid-cols-2">
-          <div>
-            <SectionHeading
-              eyebrow={`2 · Verifiable identity · live from ${NETWORK_NAME}`}
-              title="Watch verify-first work"
-              intro="This is the second part above, running for real. Resolve a real DID and see its Proof-of-Trust: the service, the organization behind it, and the verified chain up to the ecosystem root."
-            />
-            <div className="reveal mt-6">
-              <ResolveDid compact />
-            </div>
+        <Container>
+          <SectionHeading
+            eyebrow={`Verifiable identity · live from ${NETWORK_NAME}`}
+            title="Watch verify-first work"
+            intro="This is the second part above, running for real. Resolve a real DID and see its Proof-of-Trust: the service, the organization behind it, and the verified chain up to the ecosystem root."
+          />
+          <div className="reveal mt-6">
+            <ResolveDid compact />
           </div>
-          <div>
-            <SectionHeading
-              eyebrow="Testnet Ecosystems"
-              title="Latest trusted ecosystems"
-              intro="The newest ecosystems that trust-resolve as TRUSTED against the public registry."
-            />
-            <div className="reveal mt-6">
-              <Suspense
-                fallback={
-                  <div className="card p-6 font-mono text-xs text-muted">
-                    querying the network...
-                  </div>
-                }
-              >
-                <LatestEcosystems limit={5} />
-              </Suspense>
-            </div>
+        </Container>
+      </Section>
+
+      {/* Live proof — latest trusted ecosystems */}
+      <Section className="border-t border-rule">
+        <Container>
+          <SectionHeading
+            eyebrow="Testnet Ecosystems"
+            title="Latest trusted ecosystems"
+            intro="The newest ecosystems that trust-resolve as TRUSTED against the public registry."
+          />
+          <div className="reveal mt-6">
+            <Suspense
+              fallback={
+                <div className="card p-6 font-mono text-xs text-muted">
+                  querying the network...
+                </div>
+              }
+            >
+              <LatestEcosystems limit={5} />
+            </Suspense>
           </div>
         </Container>
       </Section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -105,8 +105,35 @@ export default function Home() {
         </Container>
       </Section>
 
-      {/* Live proof: the network is real */}
+      {/* Use cases teaser */}
       <Section className="border-t border-rule bg-surface">
+        <Container>
+          <SectionHeading
+            eyebrow="Use cases"
+            title="Humans and AI agents, verified the same way"
+            intro="One trust infrastructure, many entry points, built for what's coming: a bank doing reusable KYC today runs AI agents tomorrow. Every lens converges on the same verify-first primitive."
+          />
+          <div className="reveal-stagger mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {USE_CASES.map((u, i) => (
+              <Link
+                key={u.name}
+                href="/use-cases"
+                className="card group p-5 transition-colors hover:border-primary"
+              >
+                <FontAwesomeIcon
+                  icon={USE_CASE_ICONS[i]}
+                  className="h-4 w-4 text-accent"
+                />
+                <h3 className="mt-3 font-semibold text-ink">{u.name}</h3>
+                <p className="mt-2 text-sm text-muted">{u.pain}</p>
+              </Link>
+            ))}
+          </div>
+        </Container>
+      </Section>
+
+      {/* Live proof: the network is real */}
+      <Section>
         <Container className="grid gap-10 lg:grid-cols-2">
           <div>
             <SectionHeading
@@ -135,33 +162,6 @@ export default function Home() {
                 <LatestEcosystems limit={5} />
               </Suspense>
             </div>
-          </div>
-        </Container>
-      </Section>
-
-      {/* Use cases teaser */}
-      <Section>
-        <Container>
-          <SectionHeading
-            eyebrow="Use cases"
-            title="Humans and AI agents, verified the same way"
-            intro="One trust infrastructure, many entry points, built for what's coming: a bank doing reusable KYC today runs AI agents tomorrow. Every lens converges on the same verify-first primitive."
-          />
-          <div className="reveal-stagger mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {USE_CASES.map((u, i) => (
-              <Link
-                key={u.name}
-                href="/use-cases"
-                className="card group p-5 transition-colors hover:border-primary"
-              >
-                <FontAwesomeIcon
-                  icon={USE_CASE_ICONS[i]}
-                  className="h-4 w-4 text-accent"
-                />
-                <h3 className="mt-3 font-semibold text-ink">{u.name}</h3>
-                <p className="mt-2 text-sm text-muted">{u.pain}</p>
-              </Link>
-            ))}
           </div>
         </Container>
       </Section>


### PR DESCRIPTION
Home-page layout adjustments (copy + structure only, no data or route changes).

**New section order:**
1. Hero
2. Verana, in three parts
3. **Use cases** (moved up, above the live widgets)
4. Verifiable identity — Resolve a DID *(now its own full-width section)*
5. Testnet Ecosystems — Latest trusted *(now its own full-width section)*
6. Open & public + closing CTA

**Changes**
- Moved the **Use cases** teaser to sit directly after "Verana, in three parts", before the live network widgets.
- Split the former two-column live-proof grid into **two separate stacked sections** (Resolve-a-DID, then Latest trusted ecosystems), divided by a rule instead of shown side-by-side.
- Dropped the `2 · ` prefix from the verifiable-identity eyebrow → now "Verifiable identity · live from testnet".
- Swapped the `bg-surface` tint onto the Use cases section so the alternating plain/tinted section rhythm is preserved after the move.

Verified: clean production build (19/19 pages); visual check confirms the new order, the two stacked full-width live sections with a divider, the renamed eyebrow, preserved background alternation, and both live widgets still rendering real testnet data (Resolve → Trusted; Latest → MOSIP Pilot Authority).