### PR TITLE
feat(home): restructure use-cases section as "What Verana solves"

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -12,6 +12,7 @@ import {
 import { Container, Section, SectionHeading, Button } from "../components/ui";
 import PageHero from "../components/PageHero";
 import UseCaseScene, { type SceneSpec } from "../components/UseCaseScene";
+import { FoundationLogo, CouncilLogo } from "../components/OrgLogos";
 import { LINKS } from "../lib/site";
 
 export const metadata = buildMetadata({
@@ -23,49 +24,6 @@ export const metadata = buildMetadata({
 
 const PRIMARY = "var(--color-primary)";
 const ACCENT = "var(--color-accent)";
-
-/** The sister sites' exact logo lockups: the bull-horn V mark + wordmark,
- *  with each site's own coloring (Foundation: purple V + green inner,
- *  "Foundation" in purple; Council: monochrome ink). */
-function FoundationLogo() {
-  return (
-    <span
-      className="flex items-center gap-2.5 text-xl font-semibold text-ink"
-      style={{ letterSpacing: "-0.02em" }}
-    >
-      <svg width="22" height="22" viewBox="0 0 54 52" aria-hidden="true">
-        <path
-          fill="#763EF0"
-          d="M26.9932 51.6972L5.805 11.0977L2.91263 16.2161L0 10.6048L5.98725 0L26.9932 40.2483L47.9993 0L54 10.6217L51.0773 16.2161L48.1849 11.0977L26.9932 51.6972Z"
-        />
-        <path fill="#1FB57A" d="M13.696 0L26.9935 25.4637L39.9367 0H13.696Z" />
-      </svg>
-      <span>
-        Verana<span style={{ color: "#763EF0" }}>Foundation</span>
-      </span>
-    </span>
-  );
-}
-
-function CouncilLogo() {
-  return (
-    <span
-      className="flex items-center gap-2.5 text-xl font-semibold text-ink"
-      style={{ letterSpacing: "-0.02em" }}
-    >
-      <svg width="22" height="22" viewBox="0 0 54 52" aria-hidden="true">
-        <path
-          fill="var(--color-ink)"
-          d="M26.9932 51.6972L5.805 11.0977L2.91263 16.2161L0 10.6048L5.98725 0L26.9932 40.2483L47.9993 0L54 10.6217L51.0773 16.2161L48.1849 11.0977L26.9932 51.6972Z"
-        />
-        <path fill="var(--color-ink)" d="M13.696 0L26.9935 25.4637L39.9367 0H13.696Z" />
-      </svg>
-      <span>
-        Verana<span>Council</span>
-      </span>
-    </span>
-  );
-}
 
 // The separation of powers, in the site's node language. Facts as already
 // used on /ecosystems and the sister sites; everything deeper links out.

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -30,6 +30,7 @@ const COLUMNS: { title: string; links: { label: string; href: string; ext?: bool
     links: [
       { label: "Documentation", href: LINKS.docs, ext: true },
       { label: "GitHub", href: LINKS.github, ext: true },
+      { label: "Discord", href: LINKS.discord, ext: true },
       { label: "Verifiable Trust spec", href: LINKS.trustSpec, ext: true },
       { label: "VPR spec", href: LINKS.vprSpec, ext: true },
     ],

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,9 +2,17 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faDiscord, faLinkedinIn, faXTwitter } from "@fortawesome/free-brands-svg-icons";
 import Logo from "./Logo";
 import { LINKS, SITE_TAGLINE } from "../lib/site";
 import { CONSENT_KEY, CONSENT_EVENT } from "./Analytics";
+
+const SOCIALS = [
+  { label: "Discord", href: LINKS.discord, icon: faDiscord },
+  { label: "LinkedIn", href: LINKS.linkedin, icon: faLinkedinIn },
+  { label: "X", href: LINKS.x, icon: faXTwitter },
+] as const;
 
 const COLUMNS: { title: string; links: { label: string; href: string; ext?: boolean }[] }[] = [
   {
@@ -30,7 +38,6 @@ const COLUMNS: { title: string; links: { label: string; href: string; ext?: bool
     links: [
       { label: "Documentation", href: LINKS.docs, ext: true },
       { label: "GitHub", href: LINKS.github, ext: true },
-      { label: "Discord", href: LINKS.discord, ext: true },
       { label: "Verifiable Trust spec", href: LINKS.trustSpec, ext: true },
       { label: "VPR spec", href: LINKS.vprSpec, ext: true },
     ],
@@ -70,6 +77,20 @@ export default function Footer() {
           <div>
             <Logo />
             <p className="mt-4 max-w-xs text-sm text-muted">{SITE_TAGLINE}.</p>
+            <div className="mt-4 flex items-center gap-4">
+              {SOCIALS.map((s) => (
+                <a
+                  key={s.label}
+                  href={s.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={s.label}
+                  className="text-muted transition-colors hover:text-ink"
+                >
+                  <FontAwesomeIcon icon={s.icon} className="h-5 w-5" />
+                </a>
+              ))}
+            </div>
           </div>
           {COLUMNS.map((col) => (
             <div key={col.title}>

--- a/app/components/OrgLogos.tsx
+++ b/app/components/OrgLogos.tsx
@@ -1,0 +1,43 @@
+/** The sister sites' exact logo lockups: the bull-horn V mark + wordmark,
+ *  with each site's own coloring (Foundation: purple V + green inner,
+ *  "Foundation" in purple; Council: monochrome ink). Shared by /about and
+ *  the home Governance section. */
+export function FoundationLogo() {
+  return (
+    <span
+      className="flex items-center gap-2.5 text-xl font-semibold text-ink"
+      style={{ letterSpacing: "-0.02em" }}
+    >
+      <svg width="22" height="22" viewBox="0 0 54 52" aria-hidden="true">
+        <path
+          fill="#763EF0"
+          d="M26.9932 51.6972L5.805 11.0977L2.91263 16.2161L0 10.6048L5.98725 0L26.9932 40.2483L47.9993 0L54 10.6217L51.0773 16.2161L48.1849 11.0977L26.9932 51.6972Z"
+        />
+        <path fill="#1FB57A" d="M13.696 0L26.9935 25.4637L39.9367 0H13.696Z" />
+      </svg>
+      <span>
+        Verana<span style={{ color: "#763EF0" }}>Foundation</span>
+      </span>
+    </span>
+  );
+}
+
+export function CouncilLogo() {
+  return (
+    <span
+      className="flex items-center gap-2.5 text-xl font-semibold text-ink"
+      style={{ letterSpacing: "-0.02em" }}
+    >
+      <svg width="22" height="22" viewBox="0 0 54 52" aria-hidden="true">
+        <path
+          fill="var(--color-ink)"
+          d="M26.9932 51.6972L5.805 11.0977L2.91263 16.2161L0 10.6048L5.98725 0L26.9932 40.2483L47.9993 0L54 10.6217L51.0773 16.2161L48.1849 11.0977L26.9932 51.6972Z"
+        />
+        <path fill="var(--color-ink)" d="M13.696 0L26.9935 25.4637L39.9367 0H13.696Z" />
+      </svg>
+      <span>
+        Verana<span>Council</span>
+      </span>
+    </span>
+  );
+}

--- a/app/components/SolvesVisual.tsx
+++ b/app/components/SolvesVisual.tsx
@@ -1,0 +1,228 @@
+import { faUser, faServer, faArrowRightLong } from "@fortawesome/free-solid-svg-icons";
+import Glyph from "./Glyph";
+import { Badge } from "./svg";
+
+// The home "What Verana solves" before/after strip: the same connection
+// twice, once blind (unknown operator, "?") and once verify-first (operator
+// proven, check). Two nodes per panel on purpose: this is the one diagram a
+// non-technical visitor must be able to read without a legend.
+
+const INK = "var(--color-ink)";
+const MUTED = "var(--color-muted)";
+const SURFACE = "var(--color-surface)";
+const ACCENT = "var(--color-accent)";
+const SUCCESS = "var(--color-success)";
+const PERSON = "var(--color-success-ink)";
+
+function ActorNode({
+  x,
+  y,
+  icon,
+  color,
+  label,
+  sub,
+  dashed,
+}: {
+  x: number;
+  y: number;
+  icon: typeof faUser;
+  color: string;
+  label: string;
+  sub: string;
+  dashed?: boolean;
+}) {
+  const r = 15;
+  const stroke = dashed ? MUTED : color;
+  return (
+    <g>
+      <circle cx={x} cy={y} r={r + 4} fill={stroke} opacity={0.12} />
+      <circle
+        cx={x}
+        cy={y}
+        r={r}
+        fill={SURFACE}
+        stroke={stroke}
+        strokeWidth={1.5}
+        strokeDasharray={dashed ? "3 3" : undefined}
+      />
+      <g opacity={dashed ? 0.55 : 1}>
+        <Glyph icon={icon} cx={x} cy={y} size={11} color={stroke} />
+      </g>
+      <text
+        x={x}
+        y={y + r + 13}
+        textAnchor="middle"
+        fontSize={9.5}
+        fontWeight={600}
+        fontFamily="var(--font-mono)"
+        fill={INK}
+        stroke={SURFACE}
+        strokeWidth={3}
+        paintOrder="stroke"
+      >
+        {label}
+      </text>
+      <text
+        x={x}
+        y={y + r + 24}
+        textAnchor="middle"
+        fontSize={8.5}
+        fontFamily="var(--font-mono)"
+        fill={MUTED}
+        stroke={SURFACE}
+        strokeWidth={3}
+        paintOrder="stroke"
+      >
+        {sub}
+      </text>
+    </g>
+  );
+}
+
+export default function SolvesVisual() {
+  return (
+    <svg
+      viewBox="0 0 920 190"
+      className="h-auto w-full min-w-[640px]"
+      role="img"
+      aria-label="Today, you connect to a service without knowing who runs it. On Verana, the same service proves who operates it against the public registry before you connect."
+    >
+      <defs>
+        <marker
+          id="solves-success"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" fill={SUCCESS} />
+        </marker>
+      </defs>
+
+      {/* TODAY panel */}
+      <rect
+        x={10}
+        y={14}
+        width={435}
+        height={150}
+        rx={14}
+        fill={MUTED}
+        fillOpacity={0.05}
+        stroke={MUTED}
+        strokeOpacity={0.3}
+        strokeDasharray="6 5"
+      />
+      <text
+        x={28}
+        y={38}
+        fontFamily="var(--font-mono)"
+        fontSize={8.5}
+        letterSpacing="0.14em"
+        fill={MUTED}
+      >
+        TODAY
+      </text>
+      <text
+        x={227}
+        y={72}
+        textAnchor="middle"
+        fontSize={9}
+        fontFamily="var(--font-mono)"
+        fill={MUTED}
+        stroke={SURFACE}
+        strokeWidth={3}
+        paintOrder="stroke"
+      >
+        connect and hope
+      </text>
+      <line
+        x1={123}
+        y1={95}
+        x2={332}
+        y2={95}
+        stroke={MUTED}
+        strokeWidth={1.5}
+        strokeDasharray="4 4"
+        opacity={0.7}
+      />
+      {/* unknown badge */}
+      <circle cx={227} cy={95} r={8.5} fill={SURFACE} stroke={MUTED} strokeWidth={1.5} />
+      <text
+        x={227}
+        y={95}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={10}
+        fontWeight={600}
+        fontFamily="var(--font-mono)"
+        fill={MUTED}
+      >
+        ?
+      </text>
+      <ActorNode x={105} y={95} icon={faUser} color={PERSON} label="you" sub="human or AI agent" />
+      <ActorNode x={350} y={95} icon={faServer} color={ACCENT} label="a service" sub="who runs it?" dashed />
+
+      {/* transition arrow */}
+      <Glyph icon={faArrowRightLong} cx={460} cy={95} size={16} color={MUTED} />
+
+      {/* ON VERANA panel */}
+      <rect
+        x={475}
+        y={14}
+        width={435}
+        height={150}
+        rx={14}
+        fill={SUCCESS}
+        fillOpacity={0.05}
+        stroke={SUCCESS}
+        strokeOpacity={0.35}
+      />
+      <text
+        x={493}
+        y={38}
+        fontFamily="var(--font-mono)"
+        fontSize={8.5}
+        letterSpacing="0.14em"
+        fill={PERSON}
+      >
+        ON VERANA
+      </text>
+      <text
+        x={692}
+        y={72}
+        textAnchor="middle"
+        fontSize={9.5}
+        fontWeight={600}
+        fontFamily="var(--font-mono)"
+        fill={INK}
+        stroke={SURFACE}
+        strokeWidth={3}
+        paintOrder="stroke"
+      >
+        verify first, then connect
+      </text>
+      <line
+        x1={588}
+        y1={95}
+        x2={794}
+        y2={95}
+        stroke={SUCCESS}
+        strokeWidth={2}
+        opacity={0.85}
+        markerEnd="url(#solves-success)"
+      />
+      <Badge x={692} y={95} kind="check" />
+      <ActorNode x={570} y={95} icon={faUser} color={PERSON} label="you" sub="human or AI agent" />
+      <ActorNode
+        x={815}
+        y={95}
+        icon={faServer}
+        color={ACCENT}
+        label="the same service"
+        sub="Acme Corp · verified"
+      />
+    </svg>
+  );
+}

--- a/app/components/SolvesVisual.tsx
+++ b/app/components/SolvesVisual.tsx
@@ -3,9 +3,10 @@ import Glyph from "./Glyph";
 import { Badge } from "./svg";
 
 // The home "What Verana solves" before/after strip: the same connection
-// twice, once blind (unknown operator, "?") and once verify-first (operator
-// proven, check). Two nodes per panel on purpose: this is the one diagram a
-// non-technical visitor must be able to read without a legend.
+// twice, once blind (both ends unknown, "?") and once verify-first (both
+// ends checked, double-headed arrow: verification is mutual). Two nodes per
+// panel on purpose: this is the one diagram a non-technical visitor must be
+// able to read without a legend.
 
 const INK = "var(--color-ink)";
 const MUTED = "var(--color-muted)";
@@ -79,13 +80,34 @@ function ActorNode({
   );
 }
 
+/** Small "?" state badge on a node's rim: this end is unverified. */
+function UnknownBadge({ x, y }: { x: number; y: number }) {
+  return (
+    <g>
+      <circle cx={x} cy={y} r={7.5} fill={SURFACE} stroke={MUTED} strokeWidth={1.25} />
+      <text
+        x={x}
+        y={y}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={9.5}
+        fontWeight={600}
+        fontFamily="var(--font-mono)"
+        fill={MUTED}
+      >
+        ?
+      </text>
+    </g>
+  );
+}
+
 export default function SolvesVisual() {
   return (
     <svg
       viewBox="0 0 920 190"
       className="h-auto w-full min-w-[640px]"
       role="img"
-      aria-label="Today, you connect to a service without knowing who runs it. On Verana, the same service proves who operates it against the public registry before you connect."
+      aria-label="Today, you connect to a service without knowing who runs it, and the service cannot verify you either: both ends carry a question mark. On Verana, both sides verify each other against the public registry before connecting: both ends carry a check mark."
     >
       <defs>
         <marker
@@ -101,7 +123,7 @@ export default function SolvesVisual() {
         </marker>
       </defs>
 
-      {/* TODAY panel */}
+      {/* TODAY panel: both ends unknown */}
       <rect
         x={10}
         y={14}
@@ -147,27 +169,16 @@ export default function SolvesVisual() {
         strokeDasharray="4 4"
         opacity={0.7}
       />
-      {/* unknown badge */}
-      <circle cx={227} cy={95} r={8.5} fill={SURFACE} stroke={MUTED} strokeWidth={1.5} />
-      <text
-        x={227}
-        y={95}
-        textAnchor="middle"
-        dominantBaseline="central"
-        fontSize={10}
-        fontWeight={600}
-        fontFamily="var(--font-mono)"
-        fill={MUTED}
-      >
-        ?
-      </text>
       <ActorNode x={105} y={95} icon={faUser} color={PERSON} label="you" sub="human or AI agent" />
       <ActorNode x={350} y={95} icon={faServer} color={ACCENT} label="a service" sub="who runs it?" dashed />
+      {/* neither end can verify the other */}
+      <UnknownBadge x={116} y={84} />
+      <UnknownBadge x={361} y={84} />
 
       {/* transition arrow */}
       <Glyph icon={faArrowRightLong} cx={460} cy={95} size={16} color={MUTED} />
 
-      {/* ON VERANA panel */}
+      {/* ON VERANA panel: both ends verified, verification is mutual */}
       <rect
         x={475}
         y={14}
@@ -201,19 +212,19 @@ export default function SolvesVisual() {
         strokeWidth={3}
         paintOrder="stroke"
       >
-        verify first, then connect
+        verify each other, then connect
       </text>
       <line
-        x1={588}
+        x1={594}
         y1={95}
-        x2={794}
+        x2={788}
         y2={95}
         stroke={SUCCESS}
         strokeWidth={2}
         opacity={0.85}
+        markerStart="url(#solves-success)"
         markerEnd="url(#solves-success)"
       />
-      <Badge x={692} y={95} kind="check" />
       <ActorNode x={570} y={95} icon={faUser} color={PERSON} label="you" sub="human or AI agent" />
       <ActorNode
         x={815}
@@ -223,6 +234,9 @@ export default function SolvesVisual() {
         label="the same service"
         sub="Acme Corp · verified"
       />
+      {/* both ends verified */}
+      <Badge x={581} y={84} kind="check" />
+      <Badge x={826} y={84} kind="check" />
     </svg>
   );
 }

--- a/app/components/SolvesVisual.tsx
+++ b/app/components/SolvesVisual.tsx
@@ -255,7 +255,7 @@ export default function SolvesVisual() {
         icon={faUser}
         color={PERSON}
         label="you"
-        subs={["employee of Example Ltd · verified", "using agent browser ABC v1.5 · verified"]}
+        subs={["employee of Example Ltd", "using agent browser ABC v1.5"]}
       />
       <ActorNode
         x={815}
@@ -263,7 +263,7 @@ export default function SolvesVisual() {
         icon={faServer}
         color={ACCENT}
         label="Accounting Agent"
-        subs={["Acme Corp · verified", "ISO 24001 · verified"]}
+        subs={["Acme Corp", "ISO 24001"]}
       />
       {/* both ends verified */}
       <Badge x={591} y={84} kind="check" />

--- a/app/components/SolvesVisual.tsx
+++ b/app/components/SolvesVisual.tsx
@@ -255,7 +255,7 @@ export default function SolvesVisual() {
         icon={faUser}
         color={PERSON}
         label="you"
-        subs={["employee of Example Ltd", "using agent browser ABC v1.5 · verified"]}
+        subs={["employee of Example Ltd · verified", "using agent browser ABC v1.5 · verified"]}
       />
       <ActorNode
         x={815}

--- a/app/components/SolvesVisual.tsx
+++ b/app/components/SolvesVisual.tsx
@@ -1,4 +1,9 @@
-import { faUser, faServer, faArrowRightLong } from "@fortawesome/free-solid-svg-icons";
+import {
+  faUser,
+  faServer,
+  faQuestion,
+  faArrowRightLong,
+} from "@fortawesome/free-solid-svg-icons";
 import Glyph from "./Glyph";
 import { Badge } from "./svg";
 
@@ -21,7 +26,7 @@ function ActorNode({
   icon,
   color,
   label,
-  sub,
+  subs,
   dashed,
 }: {
   x: number;
@@ -29,7 +34,7 @@ function ActorNode({
   icon: typeof faUser;
   color: string;
   label: string;
-  sub: string;
+  subs: string[];
   dashed?: boolean;
 }) {
   const r = 15;
@@ -63,19 +68,22 @@ function ActorNode({
       >
         {label}
       </text>
-      <text
-        x={x}
-        y={y + r + 24}
-        textAnchor="middle"
-        fontSize={8.5}
-        fontFamily="var(--font-mono)"
-        fill={MUTED}
-        stroke={SURFACE}
-        strokeWidth={3}
-        paintOrder="stroke"
-      >
-        {sub}
-      </text>
+      {subs.map((sub, i) => (
+        <text
+          key={sub}
+          x={x}
+          y={y + r + 24 + i * 11}
+          textAnchor="middle"
+          fontSize={8.5}
+          fontFamily="var(--font-mono)"
+          fill={MUTED}
+          stroke={SURFACE}
+          strokeWidth={3}
+          paintOrder="stroke"
+        >
+          {sub}
+        </text>
+      ))}
     </g>
   );
 }
@@ -107,7 +115,7 @@ export default function SolvesVisual() {
       viewBox="0 0 920 190"
       className="h-auto w-full min-w-[640px]"
       role="img"
-      aria-label="Today, you connect to a service without knowing who runs it, and the service cannot verify you either: both ends carry a question mark. On Verana, both sides verify each other against the public registry before connecting: both ends carry a check mark."
+      aria-label="Today, an unknown entity, maybe a human, maybe a service, connects to a service that cannot be verified either: both ends carry a question mark. On Verana, both sides verify each other against the public registry before connecting: an employee of Example Ltd using a verified agent browser talks to Acme Corp's Accounting Agent, which presents verified Acme Corp and ISO 24001 credentials."
     >
       <defs>
         <marker
@@ -169,8 +177,24 @@ export default function SolvesVisual() {
         strokeDasharray="4 4"
         opacity={0.7}
       />
-      <ActorNode x={105} y={95} icon={faUser} color={PERSON} label="you" sub="human or AI agent" />
-      <ActorNode x={350} y={95} icon={faServer} color={ACCENT} label="a service" sub="who runs it?" dashed />
+      <ActorNode
+        x={105}
+        y={95}
+        icon={faQuestion}
+        color={MUTED}
+        label="unknown entity"
+        subs={["a human? a service?"]}
+        dashed
+      />
+      <ActorNode
+        x={350}
+        y={95}
+        icon={faServer}
+        color={ACCENT}
+        label="a service"
+        subs={["who runs it?"]}
+        dashed
+      />
       {/* neither end can verify the other */}
       <UnknownBadge x={116} y={84} />
       <UnknownBadge x={361} y={84} />
@@ -215,7 +239,7 @@ export default function SolvesVisual() {
         verify each other, then connect
       </text>
       <line
-        x1={594}
+        x1={604}
         y1={95}
         x2={788}
         y2={95}
@@ -225,17 +249,24 @@ export default function SolvesVisual() {
         markerStart="url(#solves-success)"
         markerEnd="url(#solves-success)"
       />
-      <ActorNode x={570} y={95} icon={faUser} color={PERSON} label="you" sub="human or AI agent" />
+      <ActorNode
+        x={580}
+        y={95}
+        icon={faUser}
+        color={PERSON}
+        label="you"
+        subs={["employee of Example Ltd", "using agent browser ABC v1.5 · verified"]}
+      />
       <ActorNode
         x={815}
         y={95}
         icon={faServer}
         color={ACCENT}
-        label="the same service"
-        sub="Acme Corp · verified"
+        label="Accounting Agent"
+        subs={["Acme Corp · verified", "ISO 24001 · verified"]}
       />
       {/* both ends verified */}
-      <Badge x={581} y={84} kind="check" />
+      <Badge x={591} y={84} kind="check" />
       <Badge x={826} y={84} kind="check" />
     </svg>
   );

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -44,7 +44,7 @@ export default function Contact() {
                   </a>{" "}
                   to chat with the community
                 </li>
-                <li>In person at IIW and standards venues</li>
+                <li>In person at IIW, GDC, DICE and standards venues</li>
                 <li>
                   Press kit on the{" "}
                   <a href="/brand" className="text-accent hover:underline">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -38,6 +38,12 @@ export default function Contact() {
                   </a>{" "}
                   to start building
                 </li>
+                <li>
+                  <a href={LINKS.discord} target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">
+                    Discord
+                  </a>{" "}
+                  to chat with the community
+                </li>
                 <li>In person at IIW and standards venues</li>
                 <li>
                   Press kit on the{" "}

--- a/app/lib/content.ts
+++ b/app/lib/content.ts
@@ -162,7 +162,7 @@ export const SOLVES: Solve[] = [
   {
     title: "Be found by what you prove",
     tone: "success",
-    body: "No search engine can find \u201cthe accounting agent of Company B\u201d. The Trust Graph indexes services by their credentials, so humans and AI agents discover each other by proof, not keywords.",
+    body: "No search engine can find \u201cthe Accounting Agent of Acme Corp\u201d. The Trust Graph indexes services by their credentials, so humans and AI agents discover each other by proof, not keywords.",
   },
 ];
 

--- a/app/lib/content.ts
+++ b/app/lib/content.ts
@@ -155,6 +155,11 @@ export const SOLVES: Solve[] = [
     body: "A service publicly attaches credentials from any ecosystem: who operates it, its ISO certificate, its licenses. Anyone can check them.",
   },
   {
+    title: "Connect without accounts",
+    tone: "accent",
+    body: "No more creating an account and pasting an API key just to wire two services together: a service or agent connects by presenting its verifiable credentials, with nothing to provision on the other side.",
+  },
+  {
     title: "Be found by what you prove",
     tone: "success",
     body: "No search engine can find \u201cthe accounting agent of Company B\u201d. The Trust Graph indexes services by their credentials, so humans and AI agents discover each other by proof, not keywords.",

--- a/app/lib/content.ts
+++ b/app/lib/content.ts
@@ -134,7 +134,10 @@ export const BUSINESS_MODELS: BusinessModel[] = [
 export type UseCase = {
   name: string;
   actors: string;
+  /** what goes wrong today (used on /use-cases) */
   pain: string;
+  /** the one-line result on Verana (used by the home teaser tiles) */
+  outcome: string;
   story: string[];
   mechanics: { label: string; href: string }[];
 };
@@ -144,6 +147,7 @@ export const USE_CASES: UseCase[] = [
     name: "Governments",
     actors: "The Republic of Utopia, its Interior Ministry, civil registries, banks, telcos, and citizens.",
     pain: "National identity is siloed: every bank and agency re-verifies people from scratch, and the state has no neutral rail to let the private sector rely on its credentials.",
+    outcome: "A reusable national ID: citizens prove who they are once, and every service can rely on it.",
     story: [
       "Utopia creates its own GovID Ecosystem on the public registry: it publishes its governance framework, defines the GovID credential schema, and accredits participants.",
       "The Interior Ministry, as issuer grantor, accredits the regional civil registries. They issue GovID credentials to citizens, who hold them in their own wallets.",
@@ -159,6 +163,7 @@ export const USE_CASES: UseCase[] = [
     name: "Sectorial ecosystems",
     actors: "Acme Corp, its employees, its suppliers, and certification bodies; the same pattern serves health, transport, notaries, and any sector body.",
     pain: "Employee access, partner onboarding, and B2B trust all rest on accounts, PDFs, and claims nobody can verify. An ISO certificate is a logo on a slide.",
+    outcome: "Diplomas, ISO certificates, and badges any partner can verify: health, transport, notaries, enterprise.",
     story: [
       "Acme registers its Main Organization service and identifies everything it runs: it issues ECS-Service credentials to its services and ECS-Badge credentials to its employees.",
       "A certification body accredited by an ISO ecosystem audits Acme and issues its ISO 9001 credential. The certification becomes provable, not asserted.",
@@ -174,6 +179,7 @@ export const USE_CASES: UseCase[] = [
     name: "Connected objects (IoT)",
     actors: "A grid operator, its smart meters and control systems, and the utilities that read them.",
     pain: "Millions of devices authenticate with baked-in secrets. When one is compromised or spoofed, nothing distinguishes a genuine meter from a fake one.",
+    outcome: "Devices that prove they are genuine before they connect to the network.",
     story: [
       "Each meter is a verifiable service: it holds an ECS-Service credential issued by the grid operator's organization service, anchored to the public registry.",
       "A utility's collector verifies each meter's credential chain before accepting readings: machine identity checked against the registry, not against a shared secret.",
@@ -187,6 +193,7 @@ export const USE_CASES: UseCase[] = [
     name: "Agentic AI",
     actors: "Acme's Corporate AI Agent, its employees, and partner companies' agents.",
     pain: "AI agents act at machine speed with no provable identity: anything can claim to be the support agent of Bank X, and no action is attributable to a responsible party.",
+    outcome: "AI agents that prove who operates them and who they act for, before they get access.",
     story: [
       "Acme's AI agent is itself a verifiable service: it holds an ECS-Service credential issued by Acme's organization service. The company visibly stands behind its agent.",
       "An employee connects: the agent verifies their ECS-Badge and their wallet's ECS-UserAgent against the registry before the first message. Verify first, then connect.",

--- a/app/lib/content.ts
+++ b/app/lib/content.ts
@@ -129,6 +129,38 @@ export const BUSINESS_MODELS: BusinessModel[] = [
   },
 ];
 
+/** The failures of online trust that Verana fixes (home "What Verana solves",
+ *  spec-v2 decision 12). Tones map each solve to its part of the three-part
+ *  spine: ecosystems = primary, identity = accent, discovery = success. */
+export type Solve = {
+  title: string;
+  body: string;
+  tone: "primary" | "accent" | "success";
+};
+
+export const SOLVES: Solve[] = [
+  {
+    title: "Verify each other",
+    tone: "accent",
+    body: "A service proves who operates it, and verifies who connects to it: humans, services, connected objects, and AI agents, all the same way.",
+  },
+  {
+    title: "Manage trust dynamically",
+    tone: "primary",
+    body: "An ecosystem's issuers and verifiers are managed live on the public registry, with open standards: no static, closed lists to maintain and distribute.",
+  },
+  {
+    title: "Attach any credential",
+    tone: "accent",
+    body: "A service publicly attaches credentials from any ecosystem: who operates it, its ISO certificate, its licenses. Anyone can check them.",
+  },
+  {
+    title: "Be found by what you prove",
+    tone: "success",
+    body: "No search engine can find \u201cthe accounting agent of Company B\u201d. The Trust Graph indexes services by their credentials, so humans and AI agents discover each other by proof, not keywords.",
+  },
+];
+
 // Use cases as concrete, named-actor narratives (spec-v2 §3.5), told through
 // the same fictional universe as the worked examples on /ecosystems.
 export type UseCase = {

--- a/app/lib/site.ts
+++ b/app/lib/site.ts
@@ -32,6 +32,7 @@ export const LINKS = {
   hologram: "https://hologram.zone",
   linkedin: "https://www.linkedin.com/company/verana-foundation/",
   x: "https://x.com/Verana_io",
+  discord: "https://discord.gg/edjaFn252q",
 } as const;
 
 export const SOCIAL_LINKS = [

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import {
   faMicrochip,
   faRobot,
   faLink,
+  faKey,
   faMagnifyingGlass,
 } from "@fortawesome/free-solid-svg-icons";
 import { Container, Section, SectionHeading, Button } from "./components/ui";
@@ -39,7 +40,7 @@ const USE_CASE_ICONS = [faLandmark, faBuilding, faMicrochip, faRobot];
 // Icons and tone colors for the "What Verana solves" rows; tones echo the
 // three-part spine (ecosystems = primary, identity = accent, discovery =
 // success) so each solve quietly points back at the part that delivers it.
-const SOLVE_ICONS = [faShieldHalved, faSitemap, faLink, faMagnifyingGlass];
+const SOLVE_ICONS = [faShieldHalved, faSitemap, faLink, faKey, faMagnifyingGlass];
 const SOLVE_TONE = {
   primary: "text-primary",
   accent: "text-accent",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import { Container, Section, SectionHeading, Button } from "./components/ui";
 import HeroGlobe from "./components/HeroGlobe";
 import LatestEcosystems from "./components/LatestEcosystems";
 import ResolveDid from "./components/ResolveDid";
+import SolvesVisual from "./components/SolvesVisual";
 import { HERO, THREE_PARTS, USE_CASES } from "./lib/content";
 import { LINKS, SITE_TAGLINE, SITE_DESCRIPTION } from "./lib/site";
 import { buildMetadata } from "./lib/seo";
@@ -105,27 +106,40 @@ export default function Home() {
         </Container>
       </Section>
 
-      {/* Use cases teaser */}
+      {/* What Verana solves: one problem, one answer, breadth as proof */}
       <Section className="border-t border-rule bg-surface">
         <Container>
           <SectionHeading
             eyebrow="Use cases"
-            title="Humans and AI agents, verified the same way"
-            intro="One trust infrastructure, many entry points, built for what's coming: a bank doing reusable KYC today runs AI agents tomorrow. Every lens converges on the same verify-first primitive."
+            title="What Verana solves"
+            intro="Online, nothing proves who is behind a service, an app, or an AI agent. So everyone re-verifies everything, or just trusts."
           />
-          <div className="reveal-stagger mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <p className="reveal mt-5 max-w-3xl text-lg leading-relaxed text-ink">
+            <strong>Verana is the public registry that fixes this.</strong>{" "}
+            Ecosystems issue verifiable credentials to their participants, and
+            anyone can check any of them, in one query. Humans and AI agents,
+            verified the same way.
+          </p>
+          <div className="card reveal mt-8 overflow-hidden">
+            <div className="overflow-x-auto p-4 sm:p-5">
+              <SolvesVisual />
+            </div>
+          </div>
+          <div className="reveal-stagger mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {USE_CASES.map((u, i) => (
               <Link
                 key={u.name}
                 href="/use-cases"
                 className="card group p-5 transition-colors hover:border-primary"
               >
-                <FontAwesomeIcon
-                  icon={USE_CASE_ICONS[i]}
-                  className="h-4 w-4 text-accent"
-                />
-                <h3 className="mt-3 font-semibold text-ink">{u.name}</h3>
-                <p className="mt-2 text-sm text-muted">{u.pain}</p>
+                <div className="flex items-center gap-2.5">
+                  <FontAwesomeIcon
+                    icon={USE_CASE_ICONS[i]}
+                    className="h-4 w-4 text-accent"
+                  />
+                  <h3 className="font-semibold text-ink">{u.name}</h3>
+                </div>
+                <p className="mt-2 text-sm text-muted">{u.outcome}</p>
               </Link>
             ))}
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -117,8 +117,9 @@ export default function Home() {
           <p className="reveal mt-5 max-w-3xl text-lg leading-relaxed text-ink">
             <strong>Verana is the public registry that fixes this.</strong>{" "}
             Ecosystems issue verifiable credentials to their participants, and
-            anyone can check any of them, in one query. Humans and AI agents,
-            verified the same way.
+            anyone can check any of them, in one query. Verification runs both
+            ways: you verify the service, and the service verifies you. Humans,
+            services, connected objects, and AI agents, verified the same way.
           </p>
           <div className="card reveal mt-8 overflow-hidden">
             <div className="overflow-x-auto p-4 sm:p-5">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import {
   faLink,
   faKey,
   faMagnifyingGlass,
+  faScaleBalanced,
 } from "@fortawesome/free-solid-svg-icons";
 import { Container, Section, SectionHeading, Button } from "./components/ui";
 import HeroGlobe from "./components/HeroGlobe";
@@ -177,8 +178,77 @@ export default function Home() {
         </Container>
       </Section>
 
+      {/* Governance: openness and no ownership, summarized from /about */}
+      <Section className="border-t border-rule">
+        <Container>
+          <SectionHeading
+            eyebrow="Governance"
+            title="Owned by no one"
+            intro="Open standards, open-source code, a permissionless public network. Two non-profits answer for the commons by name, and the model is built so that no single party can own the trust layer."
+          />
+          <div className="reveal-stagger mt-8 grid gap-4 sm:grid-cols-2">
+            <Link
+              href="/about"
+              className="card group flex flex-col p-6 transition-colors hover:border-primary"
+            >
+              <div className="flex items-center justify-between">
+                <span className="eyebrow">The steward</span>
+                <FontAwesomeIcon icon={faLandmark} className="h-4 w-4 text-primary" />
+              </div>
+              <h3 className="display mt-3 text-xl text-ink">Verana Foundation</h3>
+              <p className="mt-1 font-mono text-[11px] text-muted">
+                veranafoundation.org
+              </p>
+              <p className="mt-2 flex-1 text-sm text-muted">
+                The non-profit steward of the commons: it owns and maintains
+                the Verifiable Trust and Verifiable Public Registry
+                specifications and stewards the open-source reference
+                implementations. Its work happens in public working groups,
+                and everything it produces stays open: openly licensed specs,
+                open-source code.
+              </p>
+              <span className="mt-4 inline-flex items-center gap-2 text-sm text-accent">
+                Learn more
+                <FontAwesomeIcon
+                  icon={faArrowRightLong}
+                  className="h-3.5 w-3.5 transition-transform group-hover:translate-x-1"
+                />
+              </span>
+            </Link>
+            <Link
+              href="/about"
+              className="card group flex flex-col p-6 transition-colors hover:border-primary"
+            >
+              <div className="flex items-center justify-between">
+                <span className="eyebrow">The governor</span>
+                <FontAwesomeIcon icon={faScaleBalanced} className="h-4 w-4 text-primary" />
+              </div>
+              <h3 className="display mt-3 text-xl text-ink">Verana Council</h3>
+              <p className="mt-1 font-mono text-[11px] text-muted">
+                veranacouncil.org
+              </p>
+              <p className="mt-2 flex-1 text-sm text-muted">
+                A neutral, non-profit Swiss association that governs and
+                secures the live network and the ECS identity baseline. Up to
+                25 seats, one member one vote, membership free of charge, and
+                every member runs a validator node. It governs only the
+                constitutional commons: no instrument to reach inside the
+                sovereign ecosystems built on the network.
+              </p>
+              <span className="mt-4 inline-flex items-center gap-2 text-sm text-accent">
+                Learn more
+                <FontAwesomeIcon
+                  icon={faArrowRightLong}
+                  className="h-3.5 w-3.5 transition-transform group-hover:translate-x-1"
+                />
+              </span>
+            </Link>
+          </div>
+        </Container>
+      </Section>
+
       {/* Live proof — verifiable identity, resolve a DID */}
-      <Section>
+      <Section className="border-t border-rule">
         <Container>
           <SectionHeading
             eyebrow={`Verifiable identity · live from ${NETWORK_NAME}`}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -110,12 +110,14 @@ export default function Home() {
       <Section className="border-t border-rule bg-surface">
         <Container>
           <SectionHeading
-            eyebrow="Use cases"
+            eyebrow="Why Verana"
             title="What Verana solves"
             intro="Online, nothing proves who is behind a service, an app, or an AI agent. So everyone re-verifies everything, or just trusts."
           />
-          <p className="reveal mt-5 max-w-3xl text-lg leading-relaxed text-ink">
-            <strong>Verana is the public registry that fixes this.</strong>{" "}
+          <p className="reveal mt-5 max-w-3xl text-lg leading-relaxed text-muted">
+            <strong className="text-ink">
+              Verana is the public infrastructure that fixes this.
+            </strong>{" "}
             Ecosystems issue verifiable credentials to their participants, and
             anyone can check any of them, in one query. Verification runs both
             ways: you verify the service, and the service verifies you. Humans,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,13 +10,15 @@ import {
   faBuilding,
   faMicrochip,
   faRobot,
+  faLink,
+  faMagnifyingGlass,
 } from "@fortawesome/free-solid-svg-icons";
 import { Container, Section, SectionHeading, Button } from "./components/ui";
 import HeroGlobe from "./components/HeroGlobe";
 import LatestEcosystems from "./components/LatestEcosystems";
 import ResolveDid from "./components/ResolveDid";
 import SolvesVisual from "./components/SolvesVisual";
-import { HERO, THREE_PARTS, USE_CASES } from "./lib/content";
+import { HERO, THREE_PARTS, USE_CASES, SOLVES } from "./lib/content";
 import { LINKS, SITE_TAGLINE, SITE_DESCRIPTION } from "./lib/site";
 import { buildMetadata } from "./lib/seo";
 import { NETWORK_NAME } from "./lib/verana";
@@ -33,6 +35,16 @@ export const revalidate = 600;
 const PART_ICONS = [faSitemap, faShieldHalved, faDiagramProject];
 
 const USE_CASE_ICONS = [faLandmark, faBuilding, faMicrochip, faRobot];
+
+// Icons and tone colors for the "What Verana solves" rows; tones echo the
+// three-part spine (ecosystems = primary, identity = accent, discovery =
+// success) so each solve quietly points back at the part that delivers it.
+const SOLVE_ICONS = [faShieldHalved, faSitemap, faLink, faMagnifyingGlass];
+const SOLVE_TONE = {
+  primary: "text-primary",
+  accent: "text-accent",
+  success: "text-success-ink",
+} as const;
 
 export default function Home() {
   return (
@@ -119,10 +131,25 @@ export default function Home() {
               Verana is the public infrastructure that fixes this.
             </strong>{" "}
             Ecosystems issue verifiable credentials to their participants, and
-            anyone can check any of them, in one query. Verification runs both
-            ways: you verify the service, and the service verifies you. Humans,
-            services, connected objects, and AI agents, verified the same way.
+            anyone can check any of them, in one query. And identification is
+            only the start:
           </p>
+          <div className="reveal-stagger mt-6 grid gap-x-8 gap-y-5 sm:grid-cols-2">
+            {SOLVES.map((s, i) => (
+              <div key={s.title} className="flex gap-3.5">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-rule bg-surface-2">
+                  <FontAwesomeIcon
+                    icon={SOLVE_ICONS[i]}
+                    className={`h-4 w-4 ${SOLVE_TONE[s.tone]}`}
+                  />
+                </div>
+                <div>
+                  <h3 className="font-semibold text-ink">{s.title}</h3>
+                  <p className="mt-1 text-sm text-muted">{s.body}</p>
+                </div>
+              </div>
+            ))}
+          </div>
           <div className="card reveal mt-8 overflow-hidden">
             <div className="overflow-x-auto p-4 sm:p-5">
               <SolvesVisual />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,13 +13,13 @@ import {
   faLink,
   faKey,
   faMagnifyingGlass,
-  faScaleBalanced,
 } from "@fortawesome/free-solid-svg-icons";
 import { Container, Section, SectionHeading, Button } from "./components/ui";
 import HeroGlobe from "./components/HeroGlobe";
 import LatestEcosystems from "./components/LatestEcosystems";
 import ResolveDid from "./components/ResolveDid";
 import SolvesVisual from "./components/SolvesVisual";
+import { FoundationLogo, CouncilLogo } from "./components/OrgLogos";
 import { HERO, THREE_PARTS, USE_CASES, SOLVES } from "./lib/content";
 import { LINKS, SITE_TAGLINE, SITE_DESCRIPTION } from "./lib/site";
 import { buildMetadata } from "./lib/seo";
@@ -191,11 +191,10 @@ export default function Home() {
               href="/about"
               className="card group flex flex-col p-6 transition-colors hover:border-primary"
             >
-              <div className="flex items-center justify-between">
-                <span className="eyebrow">The steward</span>
-                <FontAwesomeIcon icon={faLandmark} className="h-4 w-4 text-primary" />
-              </div>
-              <h3 className="display mt-3 text-xl text-ink">Verana Foundation</h3>
+              <span className="eyebrow">The steward</span>
+              <h3 className="mt-3">
+                <FoundationLogo />
+              </h3>
               <p className="mt-1 font-mono text-[11px] text-muted">
                 veranafoundation.org
               </p>
@@ -219,11 +218,10 @@ export default function Home() {
               href="/about"
               className="card group flex flex-col p-6 transition-colors hover:border-primary"
             >
-              <div className="flex items-center justify-between">
-                <span className="eyebrow">The governor</span>
-                <FontAwesomeIcon icon={faScaleBalanced} className="h-4 w-4 text-primary" />
-              </div>
-              <h3 className="display mt-3 text-xl text-ink">Verana Council</h3>
+              <span className="eyebrow">The governor</span>
+              <h3 className="mt-3">
+                <CouncilLogo />
+              </h3>
               <p className="mt-1 font-mono text-[11px] text-muted">
                 veranacouncil.org
               </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1512,34 +1512,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1550,7 +1522,6 @@
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,10 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.7.3"
+  },
+  "overrides": {
+    "next": {
+      "postcss": "^8.5.10"
+    }
   }
 }


### PR DESCRIPTION
The home "Use cases" section read like a problem statement: it rendered only each lens's `pain` line, so a visitor got four paragraphs of what's broken and no resolution. Restructured per the accepted proposal (option 3 of 3): state the universal problem once, answer it once, and demote the four lenses to proof of breadth.

## New section structure (spec-v2 decision 12)

1. **Title:** "What Verana solves", eyebrow **"Why Verana"**.
2. **The problem, once, in plain words** (section intro, muted): "Online, nothing proves who is behind a service, an app, or an AI agent. So everyone re-verifies everything, or just trusts."
3. **The answer, once** (muted paragraph, only the bold lead in ink): "**Verana is the public infrastructure that fixes this.** Ecosystems issue verifiable credentials to their participants, and anyone can check any of them, in one query. Verification runs both ways: you verify the service, and the service verifies you. Humans, services, connected objects, and AI agents, verified the same way."
4. **New `SolvesVisual` before/after strip**, with **mutual verification explicit**: TODAY (dashed muted panel, "connect and hope", a "?" badge on *both* node rims: neither end can verify the other) vs ON VERANA (green panel, "verify each other, then connect", a **double-headed** verified arrow and a check badge on *both* rims, service labeled "Acme Corp · verified"). Two nodes per panel on purpose: readable without a legend. Scrolls horizontally on small screens (`min-w-[640px]` inside `overflow-x-auto`).
5. **Four compact outcome tiles** replacing the pain cards: new `outcome` field on `UseCase` in content.ts (one-line result on Verana per lens). The pain lines stay on `/use-cases`, where the full stories have room to resolve them.

## Notes
- No changes to `/use-cases` rendering; it keeps the pains and full scenes.
- Verified: clean production build (19/19 pages); visual check of the section in light and dark mode (panels, halos, badge contrast, double-headed arrow all read correctly in both).