### PR TITLE
feat(seo): refresh metadata for the merged content changes + recover stranded legal commit

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -124,6 +124,14 @@ export default function Footer() {
 
         <div className="mt-12 flex flex-col gap-4 border-t border-rule pt-6 text-xs text-muted sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-wrap gap-4">
+            <a
+              href={LINKS.foundation}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-ink"
+            >
+              © {new Date().getFullYear()} Verana Foundation
+            </a>
             <Link href="/privacy" className="hover:text-ink">Privacy</Link>
             <Link href="/terms" className="hover:text-ink">Terms</Link>
             <Link href="/cookies" className="hover:text-ink">Cookies</Link>

--- a/app/ecosystems/page.tsx
+++ b/app/ecosystems/page.tsx
@@ -38,7 +38,7 @@ import { LINKS } from "../lib/site";
 export const metadata = buildMetadata({
   title: "Sovereign ecosystems",
   description:
-    "Join or build a trust ecosystem: governance framework, credential schemas, accreditation tree, and a built-in business model, anchored on the Verifiable Public Registry.",
+    "Build your own trust ecosystem: governance framework, credential schemas, accreditation tree, and a built-in business model, anchored on the Verifiable Public Registry. Or join existing ecosystems as an accredited issuer, verifier, or holder.",
   path: "/ecosystems",
 });
 

--- a/app/lib/site.ts
+++ b/app/lib/site.ts
@@ -11,7 +11,7 @@ export const SITE_NAME = "Verana";
 export const SITE_TAGLINE = "The Open Trust Infrastructure for the Verifiable Internet";
 
 export const SITE_DESCRIPTION =
-  "Verana is the open, public, neutral trust infrastructure for the internet. Join and build sovereign digital trust ecosystems, verify any service, organization, person or AI agent before you connect, and discover who you can trust. Open standards, open-source software, owned by no one.";
+  "Verana is the open, public, neutral trust infrastructure for the internet. Build sovereign trust ecosystems on open standards (W3C Verifiable Credentials and DIDs, DIDComm) or join existing ones, verify humans, services, connected objects, and AI agents before you connect, and be found by what you prove. Open source, owned by no one.";
 
 // Default OpenGraph / Twitter image (1200x630). Lives in public/.
 export const OG_IMAGE = "/images/og-default.jpg";
@@ -39,5 +39,6 @@ export const SOCIAL_LINKS = [
   LINKS.github,
   LINKS.linkedin,
   LINKS.x,
+  LINKS.discord,
   LINKS.foundation,
 ] as const;

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -5,7 +5,7 @@ import PageHero from "../components/PageHero";
 export const metadata = buildMetadata({
   title: "Privacy policy",
   description:
-    "How verana.io handles personal data.",
+    "How the Verana Foundation (in formation, represented by 2060 OÜ) handles personal data on verana.io — the contact form, consent-gated analytics, and the live network widgets — and your rights under the GDPR.",
   path: "/privacy",
 });
 
@@ -15,35 +15,142 @@ export default function Privacy() {
       <PageHero eyebrow="Legal" title="Privacy policy" />
       <Section>
         <Container className="prose-body max-w-3xl">
-          <p>
-            This site is operated for Verana. We process the minimum personal data
-            needed to run the site and to respond to inquiries. We do not sell
-            personal data and we do not run advertising trackers.
+          <p className="font-mono text-xs uppercase tracking-wider text-muted">
+            Last updated. 2026-07-06
           </p>
-          <h2>What we collect</h2>
           <p>
-            When you submit the contact form, we process the details you provide
-            (name, email, organization, message, and optional fields) to respond
-            and to record the inquiry in our CRM. We store a timestamp of your
-            consent.
+            This page explains what personal data the{" "}
+            <strong>Verana Foundation (in formation)</strong>, represented by{" "}
+            <strong>2060 OÜ</strong>, collects through <strong>verana.io</strong>,
+            why we collect it, how long we keep it, and your rights under the EU
+            General Data Protection Regulation (GDPR). verana.io is an
+            informational site: it has <strong>no user accounts</strong>, and the
+            only personal data you can submit is through the contact form. We do
+            not sell data and do not run ad targeting or remarketing.
           </p>
-          <h2>Analytics</h2>
+
+          <h2>Data controller</h2>
           <p>
-            We may use privacy-respecting, consent-gated analytics to understand
-            aggregate usage. Analytics are disabled where no measurement id is
-            configured.
+            The Verana Foundation is in formation. Until incorporation, the data
+            controller is <strong>2060 OÜ</strong>, Ahtri tn 12, 10151 Tallinn,
+            Estonia (registry 16853041), acting as the Foundation&rsquo;s
+            steward; thereafter the incorporated Foundation. For privacy
+            matters, use the <a href="/contact">contact form</a> and begin the
+            message with <em>&ldquo;Legal:&rdquo;</em>.
           </p>
+
+          <h2>What we collect and why</h2>
+
+          <h3>Contact form</h3>
+          <p>
+            Submissions on <a href="/contact">/contact</a> (inquiry type, name,
+            email, message, optional organization/role/links) are stored in our{" "}
+            <strong>self-hosted Relaticle CRM</strong>, operated by 2060 OÜ, so
+            we can respond. IP address and user-agent are used only for rate
+            limiting and abuse detection. <strong>Legal basis.</strong> Our
+            legitimate interest in answering the inquiries you send us (GDPR
+            Art. 6(1)(f)).
+          </p>
+
+          <h3>Live network widgets</h3>
+          <p>
+            The Resolve-a-DID widget relays the DID you enter to the public
+            Verana network&rsquo;s trust resolver, through our server, to answer
+            the query. DIDs are public identifiers; we do not store them beyond
+            ordinary hosting logs. The ecosystem listings display public
+            registry data only.
+          </p>
+
+          <h3>Hosting and security</h3>
+          <p>
+            Hosting logs (IP address, user-agent) serve security and rate
+            limiting only. <strong>Legal basis.</strong> Our legitimate interest
+            in keeping the site available and abuse-free (Art. 6(1)(f)).
+          </p>
+
+          <h2>Cookies and analytics</h2>
+          <p>
+            The site itself sets <strong>no cookies</strong>; your consent
+            choice is kept in your browser&rsquo;s <code>localStorage</code>.
+            For analytics we use <strong>Google Analytics 4</strong> (Google
+            Ireland Ltd.) to measure aggregate page traffic. It is
+            consent-gated: a banner offers <strong>Accept all</strong> or{" "}
+            <strong>Essential only</strong>, and the Google Analytics tag loads
+            — and its cookies are set — <strong>only after you select
+            &ldquo;Accept all&rdquo;</strong>; choosing &ldquo;Essential
+            only&rdquo; (or making no choice) loads nothing. The lawful basis is
+            your <strong>consent</strong> (Art. 6(1)(a)), which you can withdraw
+            at any time by clearing the stored choice or via the banner&rsquo;s
+            preferences. IP addresses are anonymized; no ad networks, no
+            cross-site trackers, no selling of data. See the{" "}
+            <a href="/cookies">cookie policy</a>.
+          </p>
+
+          <h2>Processors and where data goes</h2>
+          <ul>
+            <li>
+              <strong>Google (Analytics)</strong> — Google Analytics 4, only
+              after you consent to analytics. Aggregate traffic measurement; no
+              profile data is shared.
+            </li>
+            <li>
+              <strong>Our hosting provider (EU)</strong> and our self-hosted
+              CRM, operated by 2060 OÜ.
+            </li>
+          </ul>
+          <p>
+            Cross-border transfers rely on an EC adequacy decision, the EU-US
+            Data Privacy Framework, or Standard Contractual Clauses as
+            applicable. No third-party marketing platform receives your data.
+          </p>
+
+          <h2>How long we keep it</h2>
+          <ul>
+            <li>
+              <strong>Contact-form correspondence</strong> — up to 24 months
+              from the last interaction.
+            </li>
+            <li>
+              <strong>Spam/abuse logs</strong> — up to 30 days.
+            </li>
+            <li>
+              <strong>Analytics</strong> — minimum provider retention; aggregate
+              reports contain no identifiers.
+            </li>
+          </ul>
+
           <h2>Your rights</h2>
+          <p>Under the GDPR, you may:</p>
+          <ul>
+            <li>access the personal data we hold about you;</li>
+            <li>rectify inaccurate data;</li>
+            <li>erase your data where we have no lawful basis to keep it;</li>
+            <li>restrict or object to processing;</li>
+            <li>receive a portable copy of the data you gave us;</li>
+            <li>
+              withdraw consent at any time — without affecting prior processing;
+            </li>
+            <li>
+              lodge a complaint with a supervisory authority — while stewarded
+              by 2060 OÜ, the{" "}
+              <a href="https://www.aki.ee/en" rel="noopener noreferrer">
+                Estonian Data Protection Inspectorate
+              </a>
+              .
+            </li>
+          </ul>
           <p>
-            Under the GDPR you may request access to, correction of, or deletion
-            of your personal data. Contact us through the contact form to exercise
-            these rights.
+            To exercise any right, use the <a href="/contact">contact form</a>{" "}
+            with the message prefixed <em>&ldquo;Legal:&rdquo;</em>. We respond
+            within 30 days.
           </p>
-          <h2>Retention</h2>
+
+          <h2>Changes</h2>
           <p>
-            Inquiry records are retained for as long as needed to handle the
-            request and to maintain a record of business contact, then deleted on
-            request.
+            We update this page when our practices change. The{" "}
+            <em>Last updated</em> date reflects the most recent change; prior
+            submissions remain governed by the version in force when they were
+            sent.
           </p>
         </Container>
       </Section>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -5,7 +5,7 @@ import PageHero from "../components/PageHero";
 export const metadata = buildMetadata({
   title: "Terms of use",
   description:
-    "Terms governing use of verana.io.",
+    "Terms of use for verana.io — the network and software site of Verana, operated by the Verana Foundation (in formation, represented by 2060 OÜ).",
   path: "/terms",
 });
 
@@ -15,33 +15,82 @@ export default function Terms() {
       <PageHero eyebrow="Legal" title="Terms of use" />
       <Section>
         <Container className="prose-body max-w-3xl">
-          <p>
-            This site provides information about Verana, an open, public, neutral
-            trust infrastructure. It is provided on an as-is basis, without
-            warranties of any kind.
+          <p className="font-mono text-xs uppercase tracking-wider text-muted">
+            Last updated. 2026-07-06
           </p>
-          <h2>No offer, no investment advice</h2>
           <p>
-            Nothing on this site is an offer, solicitation, or investment advice
-            regarding the VNA token or any equity. The token is described for its
-            utility only. No price, returns, or emission schedule is presented
-            here.
+            This website (<strong>verana.io</strong>) is operated by the{" "}
+            <strong>Verana Foundation (in formation)</strong>, represented by{" "}
+            <strong>2060 OÜ</strong> pre-incorporation. It is the network and
+            software site of Verana: it presents the open trust infrastructure,
+            demonstrates it with live widgets reading public Verana networks,
+            and links to the documentation and repositories. It has no user
+            accounts. By using the site you accept these terms.
           </p>
-          <h2>Open-source software</h2>
+
+          <h2>Live network data</h2>
           <p>
-            The Verana software referenced here is open source under Apache-2.0 and
-            is provided without warranty. See the repositories on GitHub for the
-            applicable license terms.
+            The Resolve-a-DID widget and the ecosystem listings display data
+            read from public Verana networks (currently the testnet) at query
+            time. Results are protocol evaluations of public registry data at a
+            point in time: they may change, and they are not an endorsement of
+            any service, organization, or credential by the Foundation. Network
+            availability is not guaranteed.
           </p>
-          <h2>Trademarks</h2>
+
+          <h2>No offer or advice</h2>
           <p>
-            The Verana name and logo are brand assets. Usage guidelines are
-            available on the brand page and in the press kit.
+            Nothing on this site is an offer, solicitation, or investment
+            advice regarding the VNA token or any equity. The VNA token is a
+            utility token of a decentralized protocol; the Foundation issues
+            and administers it but does not own it. Token economics are
+            governed by the protocol specifications, not by this site.
           </p>
+
+          <h2>Open-source software &amp; specifications</h2>
+          <p>
+            The reference software is licensed under Apache 2.0, except the
+            Verifiable Public Registry, which is AGPL-3.0 (copyright held by
+            contributors); the specifications are licensed CC BY-SA 4.0. Your
+            use of those artifacts is governed by their respective licenses,
+            available in their repositories, not by these terms.
+          </p>
+
+          <h2>Trademarks and brand assets</h2>
+          <p>
+            The Verana name and logo are brand assets, licensed{" "}
+            <strong>CC-BY 4.0</strong>. Usage guidelines are available on the{" "}
+            <a href="/brand">brand page</a> and in the press kit.
+          </p>
+
           <h2>Content license</h2>
           <p>
-            Unless otherwise noted, the text of this site is licensed under CC
-            BY-SA 4.0.
+            Unless otherwise noted, the text of this site is licensed{" "}
+            <strong>CC BY-SA 4.0</strong> and this website&rsquo;s own code is
+            open source under <strong>Apache 2.0</strong>.
+          </p>
+
+          <h2>No warranty; liability</h2>
+          <p>
+            The site is provided &ldquo;as is&rdquo;, without warranties of any
+            kind to the fullest extent permitted by law. Links to third-party
+            sites are provided for convenience and are not endorsements. Our
+            aggregate liability is limited to the fullest extent permitted by
+            law.
+          </p>
+
+          <h2>Governing law</h2>
+          <p>
+            These terms are governed by the laws of <strong>Estonia</strong>;
+            courts of Tallinn have jurisdiction, without prejudice to mandatory
+            consumer protections of your country of residence.
+          </p>
+
+          <h2>Changes</h2>
+          <p>
+            These terms may be updated as the Foundation is incorporated and
+            the site evolves. The <em>Last updated</em> date reflects the most
+            recent change.
           </p>
         </Container>
       </Section>

--- a/app/use-cases/page.tsx
+++ b/app/use-cases/page.tsx
@@ -50,7 +50,7 @@ import { USE_CASES } from "../lib/content";
 export const metadata = buildMetadata({
   title: "Use cases",
   description:
-    "One trust infrastructure, many entry points: governments, enterprise and human credentials, connected objects (IoT), and agentic AI, told as concrete stories.",
+    "One trust infrastructure, many entry points: governments, sectorial ecosystems (health, transport, notaries), connected objects (IoT), and agentic AI, told as concrete stories.",
   path: "/use-cases",
 });
 


### PR DESCRIPTION
Two things in this PR:

## 1. Recovered commit (heads-up)

The last commit pushed to the #85 branch — **`feat(legal): footer copyright and full privacy/terms pages`** — landed *after* #85 was squash-merged, so it never made it into main (the © footer line and the rebuilt /privacy and /terms pages were missing from the deployed site). It is cherry-picked here unchanged.

## 2. SEO refresh

Metadata was still describing the pre-feedback-round site. Updated to match what's now live:

- **`SITE_DESCRIPTION`** (home meta description, OG/Twitter card, JSON-LD `WebSite.description`): now build-first with the join path kept, names the standards (W3C VCs and DIDs, DIDComm), widens the convergence to *humans, services, connected objects, and AI agents*, and carries the discovery promise ("be found by what you prove").
- **/ecosystems** description leads with the page's new title framing ("Build your own trust ecosystem…"), with the join path as the second sentence.
- **/use-cases** description: "enterprise and human credentials" → **"sectorial ecosystems (health, transport, notaries)"**, matching the renamed lens.
- **JSON-LD `sameAs`**: `SOCIAL_LINKS` gains the **Discord** invite, matching the new footer icon row and the foundation site's own `sameAs`.

Also checked and already correct: /privacy and /terms meta descriptions (in the recovered commit), /about (already mentions Foundation/Council governance), /identity and /discovery (already accurate), OG image (updated separately in #83), sitemap (dynamic lastModified), layout `metadataBase`/title template.

Verified: type-check clean; production build clean (19/19); all four changes confirmed in the built HTML (`index.html`, `ecosystems.html`, `use-cases.html`).