### PR TITLE
feat(ecosystems): state that pay-per-x fee flows are privacy preserving

### DIFF
--- a/app/lib/content.ts
+++ b/app/lib/content.ts
@@ -121,11 +121,11 @@ export const BUSINESS_MODELS: BusinessModel[] = [
   },
   {
     title: "Pay-per-issuance",
-    body: "An issuer pays a fee each time it issues a credential of a schema.",
+    body: "An issuer pays a fee each time it issues a credential of a schema. Fees settle on the public registry; the credential itself stays off-chain, with its holder.",
   },
   {
     title: "Pay-per-verification",
-    body: "A verifier pays a fee each time it verifies a credential, shared with the issuer and the rest of the tree.",
+    body: "A verifier pays a fee each time it verifies a credential, shared with the issuer and the rest of the tree. Privacy preserving: payment for requesting a presentation is enforced on the registry, but the issuer cannot know or correlate who presented a credential to which verifier.",
   },
 ];
 


### PR DESCRIPTION
The Business models section's pay-per-x cards described the fee flows without their key privacy property. Added:

- **Pay-per-verification**: "Privacy preserving: payment for requesting a presentation is enforced on the registry, but the issuer cannot know or correlate who presented a credential to which verifier."
- **Pay-per-issuance**: "Fees settle on the public registry; the credential itself stays off-chain, with its holder."

Copy-only change in `BUSINESS_MODELS` (content.ts); no layout or diagram changes. Verified: type-check and production build clean (19/19), text confirmed in the built /ecosystems HTML.

No conflict with open PR #86 (different files).