### PR TITLE
feat: link the Verana Playground from home, identity, and the footer

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -37,6 +37,7 @@ const COLUMNS: { title: string; links: { label: string; href: string; ext?: bool
     title: "Build on Verana",
     links: [
       { label: "Documentation", href: LINKS.docs, ext: true },
+      { label: "Playground", href: LINKS.playground, ext: true },
       { label: "GitHub", href: LINKS.github, ext: true },
       { label: "Verifiable Trust spec", href: LINKS.trustSpec, ext: true },
       { label: "VPR spec", href: LINKS.vprSpec, ext: true },

--- a/app/identity/page.tsx
+++ b/app/identity/page.tsx
@@ -303,6 +303,27 @@ export default function Identity() {
             </div>
           </div>
 
+          {/* try it live: the Playground runs flow 1 for real */}
+          <div className="card reveal flex flex-col gap-4 p-6 sm:flex-row sm:items-center">
+            <div className="flex-1">
+              <span className="eyebrow">Try it yourself</span>
+              <h3 className="display mt-2 text-xl text-ink">
+                Run flow 1 in the Playground
+              </h3>
+              <p className="mt-2 max-w-2xl text-sm text-muted">
+                The Verana Playground walks you through the first flow for
+                real: connect a wallet on your phone to a demo issuer, receive
+                a credential, and present it to a demo verifier, live on the
+                testnet.
+              </p>
+            </div>
+            <div className="shrink-0">
+              <Button href={LINKS.playground} external>
+                Open the Playground
+              </Button>
+            </div>
+          </div>
+
           <div className="reveal flex flex-wrap gap-3">
             <Button href={LINKS.trustSpec} variant="ghost" external>
               Verifiable Trust spec

--- a/app/lib/site.ts
+++ b/app/lib/site.ts
@@ -24,6 +24,7 @@ export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID ?? "G-9H5406F02W"
 export const LINKS = {
   github: "https://github.com/verana-labs",
   docs: "https://docs.verana.io",
+  playground: "https://playground.main.demos.testnet.verana.network/",
   foundation: "https://veranafoundation.org",
   council: "https://veranacouncil.org",
   trustSpec: "https://verana-labs.github.io/verifiable-trust-spec/",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -259,6 +259,33 @@ export default function Home() {
         </Container>
       </Section>
 
+      {/* Try it yourself — the Verana Playground */}
+      <Section className="border-t border-rule bg-surface">
+        <Container>
+          <div className="card reveal flex flex-col gap-6 p-6 sm:p-8 lg:flex-row lg:items-center">
+            <div className="flex-1">
+              <span className="eyebrow">
+                Try it yourself · live on {NETWORK_NAME}
+              </span>
+              <h2 className="display mt-3 text-2xl sm:text-3xl text-ink">
+                The Verana Playground
+              </h2>
+              <p className="mt-3 max-w-2xl text-muted">
+                A guided, hands-on tour of verify-first: get a verifiable
+                credential from a demo issuer into a wallet on your phone, then
+                present it to a demo verifier, in about five minutes. No
+                account, no setup.
+              </p>
+            </div>
+            <div className="shrink-0">
+              <Button href={LINKS.playground} external>
+                Open the Playground
+              </Button>
+            </div>
+          </div>
+        </Container>
+      </Section>
+
       {/* Live proof — latest trusted ecosystems */}
       <Section className="border-t border-rule">
         <Container>


### PR DESCRIPTION
Surfaces the interactive Verana Playground (https://playground.main.demos.testnet.verana.network/, from `verana-demos`) on the site as the hands-on companion to the read-only live widgets.

## Changes

- **`app/lib/site.ts`** — new `LINKS.playground` entry (single source of truth for the URL).
- **Home** — a "Try it yourself · live on testnet" block right after the *Watch verify-first work* (Resolve-a-DID) section: one sentence + "Open the Playground" button. The home page's structure is claim → live proof; the playground is the strongest proof (the visitor gets a credential in their wallet and presents it).
- **`/identity`** — a "Run flow 1 in the Playground" card after the three connection-flow diagrams: the playground literally exercises the VUA↔VS issuance/presentation sequence drawn there.
- **Footer** — `Playground` link in the *Build on Verana* column for site-wide discoverability.

Copy follows the site rule (no em-dashes). `npx tsc --noEmit` passes.

Note: the hostname leaks the deployment instance (`main.demos`). If a stable alias (e.g. `playground.testnet.verana.network`) is set up later, only the `LINKS` entry needs updating.