### PR TITLE
feat(about): add condensed roadmap timeline section

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { Container, Section, SectionHeading, Button } from "../components/ui";
 import PageHero from "../components/PageHero";
+import Roadmap from "../components/Roadmap";
 import UseCaseScene, { type SceneSpec } from "../components/UseCaseScene";
 import { FoundationLogo, CouncilLogo } from "../components/OrgLogos";
 import { LINKS } from "../lib/site";
@@ -18,7 +19,7 @@ import { LINKS } from "../lib/site";
 export const metadata = buildMetadata({
   title: "About",
   description:
-    "Vision and mission of Verana, the open, public, neutral trust infrastructure; the roles of the Verana Foundation and the Verana Council; owned by no one.",
+    "Vision and mission of Verana, the open, public, neutral trust infrastructure; the roles of the Verana Foundation and the Verana Council; owned by no one. Plus the roadmap to mainnet.",
   path: "/about",
 });
 
@@ -170,6 +171,32 @@ export default function About() {
             membership, and program questions belong to the Foundation and the
             Council; this page only points the way.
           </p>
+        </Container>
+      </Section>
+
+      {/* Roadmap: the condensed 5-phase story; the authoritative, detailed
+          roadmap is verana-labs/verana-spec/ROADMAP.md, linked below. */}
+      <Section id="roadmap" className="pt-0">
+        <Container className="space-y-10">
+          <div className="reveal">
+            <SectionHeading
+              eyebrow="Roadmap"
+              title="From testnet to the trust layer"
+              intro="What has shipped, what is being built now, and the road to mainnet — condensed. The full, detailed roadmap lives with the specifications."
+            />
+          </div>
+
+          <Roadmap />
+
+          <a
+            href={LINKS.roadmap}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="reveal inline-flex items-center gap-2 font-mono text-xs text-accent hover:underline"
+          >
+            Full roadmap on GitHub
+            <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="h-3 w-3" />
+          </a>
 
           {/* CTA */}
           <div className="reveal flex flex-wrap gap-3">

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -28,6 +28,7 @@ const COLUMNS: { title: string; links: { label: string; href: string; ext?: bool
     title: "Ecosystem",
     links: [
       { label: "About", href: "/about" },
+      { label: "Roadmap", href: "/about#roadmap" },
       { label: "Integrations", href: "/integrations" },
       { label: "Brand", href: "/brand" },
       { label: "Contact", href: "/contact" },

--- a/app/components/Roadmap.tsx
+++ b/app/components/Roadmap.tsx
@@ -1,0 +1,103 @@
+// The condensed public roadmap: a vertical spine in the network's own history
+// colors (shipped green, current-epoch blue, quiet future). The detailed,
+// authoritative roadmap lives in verana-labs/verana-spec/ROADMAP.md; this
+// component only tells the 5-phase story.
+
+type Status = "shipped" | "progress" | "planned" | "exploring";
+
+const STATUS_CHIP: Record<Status, { label: string; className: string }> = {
+  shipped: { label: "SHIPPED", className: "chip-verified" },
+  progress: { label: "IN PROGRESS", className: "chip-progress" },
+  planned: { label: "PLANNED", className: "" },
+  exploring: { label: "EXPLORING", className: "" },
+};
+
+const PHASES: {
+  when: string;
+  title: string;
+  status: Status;
+  items: string[];
+}[] = [
+  {
+    when: "2025",
+    title: "Foundations — protocol v3 on testnet",
+    status: "shipped",
+    items: ["Testnet live", "Node, indexer, resolver", "Verifiable Service agent"],
+  },
+  {
+    when: "2026 · Q1–Q3",
+    title: "Protocol v4 — ecosystems at scale",
+    status: "progress",
+    items: [
+      "Trust graph & indexer APIs",
+      "Operator authorization",
+      "Business & cloud wallets",
+      "Wallet integrations + playground",
+    ],
+  },
+  {
+    when: "2026 · Q4",
+    title: "Protocol v5 — mainnet readiness",
+    status: "planned",
+    items: [
+      "Council-based governance",
+      "vLEI organizational trust",
+      "Security audit",
+      "Genesis validator rehearsal",
+    ],
+  },
+  {
+    when: "2027 · Q1",
+    title: "Mainnet launch",
+    status: "planned",
+    items: [
+      "Genesis ceremony",
+      "Token generation event",
+      "First credential ecosystems live",
+    ],
+  },
+  {
+    when: "2027+",
+    title: "Protocol v6 — the agentic internet",
+    status: "exploring",
+    items: [
+      "Delegation for AI agents",
+      "Enclave & HSM key custody",
+      "Trust Spanning Protocol",
+      "Personhood interop (OpenVTC)",
+    ],
+  },
+];
+
+export default function Roadmap() {
+  return (
+    <div className="roadmap-spine reveal-stagger flex flex-col gap-4">
+      {PHASES.map((phase) => {
+        const chip = STATUS_CHIP[phase.status];
+        return (
+          <div key={phase.title} data-status={phase.status} className="roadmap-stop">
+            <div className="rounded-xl border border-rule bg-surface px-5 py-4">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="font-mono text-xs tracking-[0.1em] text-muted">
+                  {phase.when}
+                </span>
+                <span className={`chip ${chip.className}`}>
+                  <span className="chip-dot" aria-hidden />
+                  {chip.label}
+                </span>
+              </div>
+              <h3 className="display mt-2 text-lg text-ink">{phase.title}</h3>
+              <ul className="mt-1.5 flex flex-wrap gap-x-6 gap-y-0.5 text-sm text-muted">
+                {phase.items.map((item) => (
+                  <li key={item} className="roadmap-item">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -186,6 +186,82 @@ body {
     );
 }
 
+/* Roadmap timeline (/about#roadmap) ---------------------------------------- */
+.chip-progress {
+  color: var(--color-accent);
+  border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-rule));
+}
+.chip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .chip-progress .chip-dot {
+    animation: roadmap-pulse 2.2s ease-in-out infinite;
+  }
+  @keyframes roadmap-pulse {
+    50% {
+      opacity: 0.35;
+    }
+  }
+}
+.roadmap-spine {
+  position: relative;
+  padding-left: 2.1rem;
+}
+/* Spine reads as the network's history: verified green over the shipped era,
+   electric blue at the current epoch, quiet rule below. Stop percentages
+   approximate the card heights; exactness doesn't matter visually. */
+.roadmap-spine::before {
+  content: "";
+  position: absolute;
+  left: 0.55rem;
+  top: 0.6rem;
+  bottom: 0.6rem;
+  width: 2px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to bottom,
+    var(--color-success) 0 16%,
+    var(--color-accent) 16% 38%,
+    var(--color-rule) 44%
+  );
+}
+.roadmap-stop {
+  position: relative;
+}
+.roadmap-stop::before {
+  content: "";
+  position: absolute;
+  left: -1.96rem;
+  top: 1.4rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-bg);
+  border: 2px solid var(--color-rule);
+}
+.roadmap-stop[data-status="shipped"]::before {
+  background: var(--color-success);
+  border-color: var(--color-success);
+}
+.roadmap-stop[data-status="progress"]::before {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 25%, transparent);
+}
+.roadmap-stop[data-status="progress"] > div {
+  border-color: color-mix(in srgb, var(--color-accent) 55%, var(--color-rule));
+}
+.roadmap-item::before {
+  content: "▪";
+  color: var(--color-primary-bright);
+  margin-right: 0.45rem;
+  font-size: 0.7em;
+  vertical-align: 1px;
+}
+
 /* Reveal-on-scroll (site-wide; observed globally by components/Reveal) ----- */
 .reveal {
   opacity: 0;

--- a/app/lib/site.ts
+++ b/app/lib/site.ts
@@ -28,6 +28,7 @@ export const LINKS = {
   foundation: "https://veranafoundation.org",
   council: "https://veranacouncil.org",
   trustSpec: "https://verana-labs.github.io/verifiable-trust-spec/",
+  roadmap: "https://github.com/verana-labs/verana-spec/blob/main/ROADMAP.md",
   vprSpec: "https://verana-labs.github.io/verifiable-trust-vpr-spec/",
   company: "https://2060.io",
   hologram: "https://hologram.zone",


### PR DESCRIPTION
## Summary

Adds a condensed, visual roadmap to the end of `/about` (anchored at `/about#roadmap`), closing the About narrative with "where we're going" before the CTA.

Design: vertical spine timeline in the Protocol Grid language — signal-green over the shipped era, electric-blue at the current epoch (pulsing IN PROGRESS chip), quiet rule below. Reuses `.chip` / `.eyebrow` / `.display` / `.reveal-stagger`; new `.chip-progress` + `.roadmap-*` styles in `globals.css`. Full light + dark, reduced-motion safe, no horizontal scrolling on mobile.

## Contents

- **`app/components/Roadmap.tsx`** — 5-phase story distilled from the detailed roadmap: 2025 v3 foundations (SHIPPED) → 2026 Q1–Q3 v4 ecosystems at scale (IN PROGRESS) → 2026 Q4 v5 mainnet readiness → 2027 Q1 mainnet launch/TGE → 2027+ v6 agentic internet (EXPLORING)
- **`app/about/page.tsx`** — new `Section id="roadmap"` after the steward/governor section; CTA moved into it so it still closes the page; "Full roadmap on GitHub" mono link
- **`app/components/Footer.tsx`** — `Roadmap → /about#roadmap` link in the Ecosystem column
- **`app/lib/site.ts`** — `LINKS.roadmap` → `verana-labs/verana-spec/ROADMAP.md`

## Notes

- The GitHub link targets `verana-spec/ROADMAP.md` on `main`, which lands with verana-labs/verana-spec#14 — merge that first (or accept a brief 404 window).
- `npm run build` passes.